### PR TITLE
LeadByte bitfield order is wrong on big endian platforms

### DIFF
--- a/source/module.h
+++ b/source/module.h
@@ -9,8 +9,13 @@
 typedef
     union {
         struct {
+#if __BIG_ENDIAN
+            unsigned int major: 3;
+            unsigned int subtype: 5;
+#else
             unsigned int subtype: 5;
             unsigned int major: 3;
+#endif
         };
         char byte;
     } LeadByte;


### PR DESCRIPTION
Use `__BIG_ENDIAN` macro to specify bit_field order. This macro may not be available outside of GCC

Ref: https://groups.google.com/d/msg/gnu.gcc.help/dHkYZVr_pcA/-q0Z0zHtbsEJ